### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,4 +1,6 @@
 name: Django CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch: null


### PR DESCRIPTION
Potential fix for [https://github.com/rizahmeds/reside/security/code-scanning/1](https://github.com/rizahmeds/reside/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, sets up Python, installs dependencies, and runs tests (with no steps that require write access to the repository or other resources), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add it at the top level, just after the `name` and before `on`, to ensure all jobs inherit these minimal permissions unless overridden.

**Required changes:**  
- Edit `.github/workflows/django.yml`.
- Insert a `permissions:` block with `contents: read` after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
